### PR TITLE
Backup changes

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -8,7 +8,7 @@ class Setting < ApplicationRecord
   include EncryptValue
   include PermissionName
 
-  TYPES = %w{integer boolean hash array string}
+  TYPES = %w{integer boolean hash array string url}
   NONZERO_ATTRS = %w{puppet_interval idle_timeout entries_per_page outofsync_interval}
   # constant BLANK_ATTRS is deprecated and all settings without custom validation allow blank values
   # if you wish to validate non-empty arrays, please add validation through the new setting DSL
@@ -44,8 +44,9 @@ class Setting < ApplicationRecord
   validates_with ValueValidator, :if => proc { |s| Foreman.settings.ready? && s.respond_to?("validate_#{s.name}") }
   validates :value, :array_hostnames_ips => true, :if => proc { |s| ARRAY_HOSTNAMES.include? s.name }
   validates :value, :email => true, :if => proc { |s| EMAIL_ATTRS.include? s.name }
+  validates :value, :http_url => { allow_blank: true }, :if => proc { |s| s.settings_type == "url" }
+
   before_save :clear_value_when_default
-  before_save :encrypt_url_if_password_present, :if => proc { |s| s.name == "http_proxy" && s.value.present? }
   validate :validate_frozen_attributes
   before_validation :remove_whitespaces, :if => proc { |s| s.settings_type == "array" }
   # Custom validations are added from SettingManager class
@@ -94,6 +95,9 @@ class Setting < ApplicationRecord
   end
 
   def value=(v)
+    if setting_definition&.settings_type == "url"
+      update_encrypted_flag_from_url(v)
+    end
     v = v.to_yaml unless v.nil?
     # the has_attribute is for enabling DB migrations on older versions
     if setting_definition&.encrypted?
@@ -143,7 +147,7 @@ class Setting < ApplicationRecord
         invalid_value_error _("must be an array")
       end
 
-    when "string", "text", nil
+    when "string", "text", "url", nil
       # string is taken as default setting type for parsing
       intermediate = val
       intermediate = intermediate.to_s.strip unless NOT_STRIPPED.include?(name)
@@ -285,11 +289,13 @@ class Setting < ApplicationRecord
     self[:value] = value.each { |a| a.strip! if a.respond_to? :strip! }
   end
 
-  def encrypt_url_if_password_present
-    uri = URI.parse(value)
-    return unless uri.userinfo&.include?(':')
-
-    self[:value] = encrypt_field(value)
+  # Check if URL contains user:password credentials
+  def update_encrypted_flag_from_url(value)
+    if URI.parse(value).userinfo&.include?(':')
+      setting_definition&.encrypted = true
+    else
+      setting_definition&.encrypted = false
+    end
   rescue URI::InvalidURIError
     errors.add(:value, _("Invalid URI '#{value}'"))
   end

--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -75,7 +75,7 @@ class SettingPresenter
   end
 
   def settings_type
-    attribute(:settings_type) || Setting.setting_type_from_value(default)
+    @attributes&.[]('settings_type')&.value || Setting.setting_type_from_value(default)
   end
 
   def matches_search_query?(query)

--- a/app/registries/foreman/setting_manager.rb
+++ b/app/registries/foreman/setting_manager.rb
@@ -101,7 +101,7 @@ module Foreman
       end
 
       def available_types
-        [:boolean, :integer, :float, :string, :text, :hash, :array]
+        [:boolean, :integer, :float, :string, :text, :hash, :array, :url]
       end
 
       # Adds setting definition

--- a/app/services/foreman/renderer/scope/macros/base.rb
+++ b/app/services/foreman/renderer/scope/macros/base.rb
@@ -7,6 +7,7 @@ module Foreman
           include Foreman::Renderer::Errors
           include ::Foreman::ForemanURLRenderer
           include ActiveSupport::NumberHelper
+          include HiddenValue
 
           attr_reader :template_name, :medium_provider
 
@@ -32,17 +33,24 @@ module Foreman
 
           apipie :method, 'Returns the value of global setting' do
             settings = Foreman::Renderer.config.allowed_global_settings.sort.map { |s| "__#{s}__" }.join(', ')
-            desc "Not not all settings are exposed, only those which are allowed via safe mode: #{settings}"
+            desc "Not all settings are exposed, only those which are allowed via safe mode: #{settings}. Encrypted/sensitive settings return '*****' instead of their actual values for security."
             required :name, String, desc: 'the name of the setting which can be found by hovering the setting with mouse cursor in the UI, or via API/CLI'
             optional :blank_default, Object, desc: 'if the setting is not set to any value, this value will be returned instead', default: nil
             raises error: FilteredGlobalSettingAccessed, desc: 'when user setting is not accessible in safe mode'
-            returns Object, desc: 'The value of global setting, e.g. String, Integer, Array, Provisioning Template etc'
+            returns Object, desc: 'The value of global setting, e.g. String, Integer, Array, Provisioning Template etc. Returns "*****" for encrypted settings.'
             example "global_setting('outofsync_interval', 30) # => 30"
+            example "global_setting('http_proxy') # => '*****' if it contains credentials"
           end
           def global_setting(name, blank_default = nil)
             raise FilteredGlobalSettingAccessed.new(name: name) if Setting[:safemode_render] && !Foreman::Renderer.config.allowed_global_settings.include?(name.to_sym)
             setting = Foreman.settings.find(name)
-            (setting.settings_type != "boolean" && setting.value.blank?) ? blank_default : setting.value
+
+            # Hide encrypted/sensitive settings by returning a masked value
+            if setting.encrypted?
+              setting.hidden_value
+            else
+              (setting.settings_type != "boolean" && setting.value.blank?) ? blank_default : setting.value
+            end
           end
 
           apipie :method, 'Returns true if plugin with a given name is installed in this Foreman instance' do

--- a/config/initializers/f_foreman_settings_general.rb
+++ b/config/initializers/f_foreman_settings_general.rb
@@ -36,11 +36,10 @@ Foreman::SettingManager.define(:foreman) do
       default: N_("Version") + " $VERSION",
       full_name: N_('Login page footer text'))
     setting('http_proxy',
-      type: :string,
+      type: :url,
       description: N_('Set an HTTP(s) proxy for all outgoing HTTP(S) connections from Foreman. System-wide proxies must be configured at the operating system level.'),
       default: nil,
       full_name: N_('HTTP(S) proxy'))
-    validates(:http_proxy, { http_url: { allow_blank: true } })
     setting('http_proxy_except_list',
       type: :array,
       description: N_('Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default.'),

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -245,6 +245,37 @@ class SettingTest < ActiveSupport::TestCase
     check_length_must_be_under_8 'entries_per_page'
   end
 
+  test "http_url validation applies to URL type settings" do
+    url_setting = Setting.new(name: 'test_url_setting', value: 'invalid url')
+    url_setting.stubs(:settings_type).returns('url')
+    url_setting.valid?
+    assert_includes url_setting.errors[:value], "Invalid HTTP(S) URL"
+  end
+
+  test "http_url validation allows blank values for URL settings" do
+    setting = Setting.new(name: 'test_url_setting', value: '')
+    setting.stubs(:settings_type).returns('url')
+    setting.valid?
+    assert_not_includes setting.errors[:value], "Invalid HTTP(S) URL"
+  end
+
+  test "http_url validation allows valid URLs for URL settings" do
+    setting = Setting.new(name: 'test_url_setting', value: 'http://example.com')
+    setting.stubs(:settings_type).returns('url')
+    setting.valid?
+    assert_not_includes setting.errors[:value], "Invalid HTTP(S) URL"
+  end
+
+  test "non-URL settings can contain invalid URL format without http_url validation error" do
+    %w[string integer boolean].each do |type|
+      setting = Setting.new(name: "test_#{type}_setting", value: 'not a url at all')
+      setting.stubs(:settings_type).returns(type)
+      setting.valid?
+      assert_not_includes setting.errors[:value], "Invalid HTTP(S) URL",
+        "#{type} setting should not get http_url validation"
+    end
+  end
+
   # test parsing string values
   test "parse boolean attribute from string" do
     check_parsed_value "boolean", true, "true"
@@ -419,24 +450,55 @@ class SettingTest < ActiveSupport::TestCase
     end
 
     test 'adds an error when URL is invalid' do
-      url = 'http://example.com/hello world'
-      attrs = { :name => "http_proxy", :value => url }
-      setting = Setting.find_or_create_by(attrs)
+      attrs = { :name => "test_url_setting", :value => 'http://example.com/hello world' }
+      setting = Setting.find_or_create_by!(attrs)
+      setting.stubs(:settings_type).returns('url')
 
-      refute setting.is_decryptable?(setting.read_attribute(:value)), 'Expected URL not to be encrypted'
+      setting.valid?
       assert_includes setting.errors[:value], "Invalid HTTP(S) URL"
     end
-    test 'no error when URL is invalid and the setting is not http_proxy' do
-      url = 'http://example.com/hello world'
-      attrs = { :name => "not_http_proxy", :value => url }
-      Setting.find_or_create_by!(attrs)
+
+    test 'encrypted? should return true when URL contains password' do
+      url = 'http://user:pass@example.com'
+      attrs = { :name => "http_proxy", :value => url }
+      setting = Setting.find_or_create_by!(attrs)
+
+      assert setting.encrypted?, 'encrypted? should return true when URL contains password'
     end
 
-    test 'encrypted? should return false when URL contains password' do
-      setting = Setting.new(name: 'http_proxy', value: 'http://user:pass@example.comjkjk')
-      setting.save!
+    test 'encrypted? should return false when URL does not contain password' do
+      url = 'http://user@example.com'
+      attrs = { :name => "http_proxy", :value => url }
+      setting = Setting.find_or_create_by!(attrs)
 
-      assert_not setting.encrypted?, 'encrypted? should return false when URL contains password'
+      refute setting.encrypted?, 'encrypted? should not return true when URL does not contain password'
+    end
+  end
+
+  describe 'update_encrypted_flag_from_url' do
+    test 'sets encrypted flag to true when URL contains password' do
+      setting = Setting.new(name: 'test_url', value: '')
+      setting_definition = mock('setting_definition')
+      setting_definition.expects(:encrypted=).with(true)
+      setting.stubs(:setting_definition).returns(setting_definition)
+
+      setting.send(:update_encrypted_flag_from_url, 'http://user:pass@example.com')
+    end
+
+    test 'sets encrypted flag to false when URL has no password' do
+      setting = Setting.new(name: 'test_url', value: '')
+      setting_definition = mock('setting_definition')
+      setting_definition.expects(:encrypted=).with(false)
+      setting.stubs(:setting_definition).returns(setting_definition)
+
+      setting.send(:update_encrypted_flag_from_url, 'http://user@example.com')
+    end
+
+    test 'adds error when URL is invalid' do
+      setting = Setting.new(name: 'test_url', value: '')
+      setting.send(:update_encrypted_flag_from_url, '://example.com')
+
+      assert_includes setting.errors[:value], "Invalid URI '://example.com'"
     end
   end
 end

--- a/test/unit/foreman/renderer/renderers_shared_tests.rb
+++ b/test/unit/foreman/renderer/renderers_shared_tests.rb
@@ -78,6 +78,18 @@ module RenderersSharedTests
       assert_equal 'PASS', renderer.render(source, @scope)
     end
 
+    test "global_setting returns masked for encrypted setting" do
+      Setting.find_or_create_by!(name: 'http_proxy', value: 'http://user:pass@example.com')
+      source = OpenStruct.new(content: '<%= global_setting("http_proxy") %>')
+      assert_equal '*****', renderer.render(source, @scope)
+    end
+
+    test "global_setting returns actual value for url without password" do
+      Setting.find_or_create_by!(name: 'http_proxy', value: 'http://user@example.com')
+      source = OpenStruct.new(content: '<%= global_setting("http_proxy") %>')
+      assert_equal 'http://user@example.com', renderer.render(source, @scope)
+    end
+
     test "global_setting helper method with special case 'false'" do
       source = OpenStruct.new(content: '<%= global_setting("default_pxe_item_global") %>')
       Setting[:default_pxe_item_global] = false

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingValueCell.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingValueCell.js
@@ -10,8 +10,19 @@ const SettingValueCell = ({ setting, index }) => {
   const [editingRow, setEditingRow] = useState(false);
   const [settingData, setSettingData] = useState(setting);
   const updateSetting = newValue => {
-    const newSetting = { ...setting, value: newValue };
-    setSettingData({ ...settingData, value: formatEncryptedValue(newSetting) });
+    // newValue might be the raw value or a full setting object from the server
+    const updatedSetting =
+      newValue && typeof newValue === 'object' && newValue.id
+        ? { ...settingData, ...newValue }
+        : { ...settingData, value: newValue };
+
+    // Ensure the displayed value respects encryption based on the updated flag
+    const displaySetting = {
+      ...updatedSetting,
+      value: formatEncryptedValue(updatedSetting),
+    };
+
+    setSettingData(displaySetting);
     setEditingRow(false);
   };
 

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingValueEdit.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingValueEdit.js
@@ -59,11 +59,14 @@ const SettingValueEdit = ({ setting, updateSetting }) => {
     setLoading(false);
   };
 
-  const successCallback = submitValue => {
-    updateSetting(submitValue);
+  const successCallback = (response, submitValue) => {
+    const updated = response?.data;
+    updateSetting(updated || submitValue);
 
     if (setting.name === SETTING_NEW_HOSTS_PAGE) {
-      const bool = value === 'true';
+      const rawVal =
+        (updated && updated.value) !== undefined ? updated.value : value;
+      const bool = String(rawVal) === 'true';
       setContext(context => {
         context.metadata.UISettings.displayNewHostsPage = bool;
         return context;
@@ -92,7 +95,7 @@ const SettingValueEdit = ({ setting, updateSetting }) => {
       url: SETTING_UPDATE_PATH.replace(':id', setting.id),
       params: { ...setting, value: splitValue },
       key: `${setting.id}-EDIT`,
-      handleSuccess: () => successCallback(splitValue),
+      handleSuccess: response => successCallback(response, splitValue),
       handleError: errorCallback,
       errorToast: error => {
         const msg =

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/components/__tests__/SettingCell.test.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/components/__tests__/SettingCell.test.js
@@ -6,19 +6,71 @@ import {
   withoutFullName,
 } from '../../../SettingRecords/__tests__/SettingRecords.fixtures';
 
+import React from 'react';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import { act } from 'react-dom/test-utils';
 import SettingValue from '../SettingValue';
+import SettingValueCell from '../SettingValueCell';
 
 const fixtures = {
-  'render ordinary': {
-    setting: stringSetting,
-  },
-  'render encrypted with fullName': {
-    setting: rootPass,
-  },
-  'render without fullName': {
-    setting: withoutFullName,
-  },
+  'render ordinary': { setting: stringSetting },
+  'render encrypted with fullName': { setting: rootPass },
+  'render without fullName': { setting: withoutFullName },
 };
 
 describe('SettingCell', () =>
   testComponentSnapshotsWithFixtures(SettingValue, fixtures));
+
+describe('SettingValueCell encrypted flag updates after save', () => {
+  const mockStore = configureMockStore();
+  const store = mockStore({});
+
+  it('updates displayed value and encrypted flag from server response', () => {
+    const setting = { id: 'http_proxy', name: 'http_proxy', value: '', encrypted: false };
+    const wrapper = mount(
+      <Provider store={store}>
+        <SettingValueCell setting={setting} index={0} />
+      </Provider>
+    );
+
+    // open edit
+    act(() => {
+      wrapper.find(`button#${setting.name}`).simulate('click');
+    });
+    wrapper.update();
+
+    // simulate updateSetting called by SettingValueEdit success
+    const updated = { id: 'http_proxy', name: 'http_proxy', value: 'http://user:pass@h:1', encrypted: true };
+    act(() => {
+      wrapper.find('SettingValueEdit').props().updateSetting(updated);
+    });
+    wrapper.update();
+
+    // rendered value should be masked
+    expect(wrapper.find('.setting-value').first().text()).toBe('*****');
+  });
+
+  it('updates displayed value when encryption flag is removed', () => {
+    const setting = { id: 'http_proxy', name: 'http_proxy', value: '*****', encrypted: true };
+    const wrapper = mount(
+      <Provider store={store}>
+        <SettingValueCell setting={setting} index={0} />
+      </Provider>
+    );
+
+    act(() => {
+      wrapper.find(`button#${setting.name}`).simulate('click');
+    });
+    wrapper.update();
+
+    const updated = { id: 'http_proxy', name: 'http_proxy', value: 'http://user@host:8080', encrypted: false };
+    act(() => {
+      wrapper.find('SettingValueEdit').props().updateSetting(updated);
+    });
+    wrapper.update();
+
+    expect(wrapper.find('.setting-value').first().text()).toBe('http://user@host:8080');
+  });
+});


### PR DESCRIPTION
**Description**
This PR is a follow-up to #10525, implementing the new approach suggested in https://github.com/theforeman/foreman/pull/10525#pullrequestreview-2784014199.

* Introduces a new **`URL`** setting type for consistent validation and storage.
* Masks sensitive parts of URLs (e.g., credentials) when displayed.
* Updates existing logic to improve security and prevent accidental exposure.

**How to test**

1. Go to *Settings* → update the **HTTP(S) proxy** setting:

   * **With credentials**:
     `https://USER:SECRETPASSWORD@squid-server:3129`
     → credentials should be hidden in audit logs, provisioning templates, and the UI.
   * **Without credentials**:
     `https://USER@squid-server:3129`
     → value should be visible in audit logs, provisioning templates, and the UI.
   * **Invalid value**:
     `https:/USER:SECRETPASSWORD@squid-server:3129`
     → should show an error in the UI and not update the setting.

2. Verify that other settings are unaffected.

3. Create a provisioning template with:
   ```erb
   HTTP Proxy: <%= global_setting('http_proxy') %>
   ```

   → In *Preview*, ensure values with credentials are hidden.

4. When updating values with credentials, confirm you see the following message in the logs:
   ```erb
   Setting (16) update event on value [old value], [redacted]
   ```
**Follow-up**
Migrate other string-based settings to use the new `URL` type.